### PR TITLE
Remove platform from add-on name

### DIFF
--- a/game.libretro.mrboom/addon.xml.in
+++ b/game.libretro.mrboom/addon.xml.in
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="game.libretro.mrboom"
-		name="Mr.Boom (Bomberman)"
+		name="Mr.Boom"
 		version="4.5.0"
 		provider-name="Libretro">
 	<requires>
@@ -15,10 +15,8 @@
 		<supports_standalone>true</supports_standalone>
 	</extension>
 	<extension point="xbmc.addon.metadata">
-		<summary lang="en_GB">Mr.Boom (Bomberman) 4.5</summary>
-		<description lang="en_GB">Mr.Boom is a freeware 8 players Bomberman clone.
-
-Supports up to 8 players and features like pushing bombs, remote controls and kangaroo riding...</description>
+		<summary lang="en_GB">Mr.Boom 4.5</summary>
+		<description lang="en_GB">Mr.Boom is a freeware 8-player clone of the popular game. It supports features like pushing bombs, remote controls and kangaroo riding.</description>
 		<license></license>
 		<platform>@PLATFORM@</platform>
 		<assets>


### PR DESCRIPTION
We probably shouldn't have "bomberman" appear on the homescreen the user first sees. This should be done by kodi-game-scripting, but for now I'm hardcoding the removal here. 